### PR TITLE
fix: clean up transaction and event subscriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zkverifyjs",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zkverifyjs",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@polkadot/api": "16.5.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zkverifyjs",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Submit proofs to zkVerify and query proof state with ease using our npm package.",
   "author": "zkVerify <web3-platform@zkverify.io>",
   "license": "GPL-3.0",

--- a/src/api/aggregation/index.test.ts
+++ b/src/api/aggregation/index.test.ts
@@ -37,9 +37,7 @@ describe('subscribeToNewAggregationReceipts', () => {
     null;
   let mockHeader: any;
   let emitter: EventEmitter;
-  let mockApiAtInstance: {
-    query: { system: { events: jest.Mock<() => Promise<any>> } };
-  };
+  let mockEventsAt: jest.Mock<(blockHash: any) => Promise<any>>;
 
   beforeEach(() => {
     jest.useRealTimers();
@@ -50,15 +48,9 @@ describe('subscribeToNewAggregationReceipts', () => {
       number: { toNumber: () => 123, toBigInt: () => BigInt(123) },
     };
 
-    mockApiAtInstance = {
-      query: {
-        system: {
-          events: jest
-            .fn<() => Promise<any>>()
-            .mockImplementation(async () => Promise.resolve([] as any)),
-        },
-      },
-    };
+    mockEventsAt = jest
+      .fn<(blockHash: any) => Promise<any>>()
+      .mockImplementation(async () => Promise.resolve([] as any));
 
     api = {
       rpc: {
@@ -71,17 +63,16 @@ describe('subscribeToNewAggregationReceipts', () => {
           ) as Mock,
         },
       },
-      at: jest.fn().mockImplementation(async (blockHash: any) => {
-        return Promise.resolve(mockApiAtInstance);
-      }),
+      query: {
+        system: {
+          events: { at: mockEventsAt },
+        },
+      },
     } as unknown as ApiPromise;
 
     callback = jest.fn();
     emitter = new EventEmitter();
     finalizedHeadsCallback = null;
-    mockApiAtInstance.query.system.events.mockImplementation(async () =>
-      Promise.resolve([] as any),
-    );
   });
 
   afterEach(() => {
@@ -102,9 +93,7 @@ describe('subscribeToNewAggregationReceipts', () => {
       [targetDomainId, targetAggregationId, receipt],
     );
 
-    mockApiAtInstance.query.system.events.mockImplementation(async () =>
-      Promise.resolve([mockEvent]),
-    );
+    mockEventsAt.mockImplementation(async () => Promise.resolve([mockEvent]));
     const emitSpy = jest.spyOn(emitter, 'emit');
     const subscriptionPromise = subscribeToNewAggregationReceipts(
       api,
@@ -143,6 +132,8 @@ describe('subscribeToNewAggregationReceipts', () => {
       }),
     );
     expect(mockApiUnsubscribe).toHaveBeenCalled();
+    expect((emitter as any)._cleanups?.length ?? 0).toBe(0);
+    expect(emitter.listenerCount(ZkVerifyEvents.Unsubscribe)).toBe(0);
   });
 
   it('should reject immediately if aggregationId is provided without domainId', async () => {
@@ -162,9 +153,7 @@ describe('subscribeToNewAggregationReceipts', () => {
   it('should reject with timeout error if no matching event received within timeout', async () => {
     jest.useFakeTimers();
     const timeoutDuration = 10;
-    mockApiAtInstance.query.system.events.mockImplementation(async () =>
-      Promise.resolve([]),
-    );
+    mockEventsAt.mockImplementation(async () => Promise.resolve([]));
     const emitSpy = jest.spyOn(emitter, 'emit');
     const subscriptionPromise = subscribeToNewAggregationReceipts(
       api,
@@ -216,14 +205,14 @@ describe('subscribeToNewAggregationReceipts', () => {
     );
     const emitSpy = jest.spyOn(emitter, 'emit');
     subscribeToNewAggregationReceipts(api, callback, undefined, emitter).catch(
-      (err) => {},
+      () => {},
     );
 
     await new Promise((resolve) => setImmediate(resolve));
     expect(finalizedHeadsCallback).toBeInstanceOf(Function);
     if (!finalizedHeadsCallback) throw new Error('Callback not captured');
 
-    mockApiAtInstance.query.system.events.mockImplementation(async () =>
+    mockEventsAt.mockImplementation(async () =>
       Promise.resolve([mockEvent1, mockEvent2]),
     );
     await finalizedHeadsCallback(mockHeader);
@@ -244,9 +233,7 @@ describe('subscribeToNewAggregationReceipts', () => {
       hash: { toHex: () => '0xhash2' },
       number: { toNumber: () => 124, toBigInt: () => BigInt(124) },
     };
-    mockApiAtInstance.query.system.events.mockImplementation(async () =>
-      Promise.resolve([mockEvent3]),
-    );
+    mockEventsAt.mockImplementation(async () => Promise.resolve([mockEvent3]));
     await finalizedHeadsCallback(header2);
     await new Promise((resolve) => setImmediate(resolve));
     expect(callback).toHaveBeenCalledTimes(2);
@@ -295,15 +282,13 @@ describe('subscribeToNewAggregationReceipts', () => {
       callback,
       { domainId: targetDomainId },
       emitter,
-    ).catch((err) => {});
+    ).catch(() => {});
 
     await new Promise((resolve) => setImmediate(resolve));
     expect(finalizedHeadsCallback).toBeInstanceOf(Function);
     if (!finalizedHeadsCallback) throw new Error('Callback not captured');
 
-    mockApiAtInstance.query.system.events.mockImplementation(async () =>
-      Promise.resolve([mockEvent1]),
-    );
+    mockEventsAt.mockImplementation(async () => Promise.resolve([mockEvent1]));
     await finalizedHeadsCallback(mockHeader);
     await new Promise((resolve) => setImmediate(resolve));
     expect(callback).toHaveBeenCalledTimes(1);
@@ -322,7 +307,7 @@ describe('subscribeToNewAggregationReceipts', () => {
       hash: { toHex: () => '0xhash2' },
       number: { toNumber: () => 124, toBigInt: () => BigInt(124) },
     };
-    mockApiAtInstance.query.system.events.mockImplementation(async () =>
+    mockEventsAt.mockImplementation(async () =>
       Promise.resolve([mockEventOtherDomain]),
     );
     await finalizedHeadsCallback(header2);
@@ -335,9 +320,7 @@ describe('subscribeToNewAggregationReceipts', () => {
       hash: { toHex: () => '0xhash3' },
       number: { toNumber: () => 125, toBigInt: () => BigInt(125) },
     };
-    mockApiAtInstance.query.system.events.mockImplementation(async () =>
-      Promise.resolve([mockEvent2]),
-    );
+    mockEventsAt.mockImplementation(async () => Promise.resolve([mockEvent2]));
     await finalizedHeadsCallback(header3);
     await new Promise((resolve) => setImmediate(resolve));
     expect(callback).toHaveBeenCalledTimes(2);
@@ -360,5 +343,134 @@ describe('subscribeToNewAggregationReceipts', () => {
 
     expect(mockApiUnsubscribe).not.toHaveBeenCalled();
     expect(emitSpy).not.toHaveBeenCalledWith(ZkVerifyEvents.Unsubscribe);
+  });
+});
+
+describe('subscribeToNewAggregationReceipts — bug fixes', () => {
+  let api: ApiPromise;
+  let mockApiUnsubscribe: jest.Mock<() => void>;
+  let mockEventsAt: jest.Mock<(blockHash: any) => Promise<any>>;
+  let resolveSubscribe!: (fn: () => void) => void;
+  let rejectSubscribe!: (err: unknown) => void;
+
+  beforeEach(() => {
+    jest.useRealTimers();
+    mockApiUnsubscribe = jest.fn();
+
+    mockEventsAt = jest
+      .fn<(blockHash: any) => Promise<any>>()
+      .mockImplementation(async () => Promise.resolve([] as any));
+
+    api = {
+      rpc: {
+        chain: {
+          subscribeFinalizedHeads: jest.fn(() => {
+            // Hand back a Promise we manually settle from the test, so we can
+            // simulate the unsubscribe-fn arriving after cleanup has run.
+            return new Promise((resolve, reject) => {
+              resolveSubscribe = resolve;
+              rejectSubscribe = reject;
+            });
+          }) as Mock,
+        },
+      },
+      query: {
+        system: {
+          events: { at: mockEventsAt },
+        },
+      },
+    } as unknown as ApiPromise;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  // Bug 1
+  it('invokes a late-arriving unsubscribe fn when cleanup() ran first', async () => {
+    const emitter = new EventEmitter();
+    const callback = jest.fn();
+
+    subscribeToNewAggregationReceipts(api, callback, undefined, emitter).catch(
+      () => {},
+    );
+
+    // Simulate the user manually unsubscribing before subscribeFinalizedHeads
+    // has finished its handshake with the node.
+    unsubscribe(emitter);
+
+    // Now the polkadot subscribe handshake completes, late.
+    resolveSubscribe(mockApiUnsubscribe);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // The unsubscribe fn must have been invoked, NOT silently captured into
+    // an orphaned closure.
+    expect(mockApiUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  // Bug 5
+  it('cleans up multiple subscriptions sharing the same emitter', async () => {
+    const emitter = new EventEmitter();
+    const callbackA = jest.fn();
+    const callbackB = jest.fn();
+    const apiUnsubscribeB = jest.fn();
+
+    let resolveA!: (fn: () => void) => void;
+    let resolveB!: (fn: () => void) => void;
+    let call = 0;
+    (
+      api.rpc.chain.subscribeFinalizedHeads as unknown as jest.Mock
+    ).mockImplementation(() => {
+      call += 1;
+      return new Promise((resolve) => {
+        if (call === 1) resolveA = resolve;
+        else resolveB = resolve;
+      });
+    });
+
+    subscribeToNewAggregationReceipts(api, callbackA, undefined, emitter).catch(
+      () => {},
+    );
+    subscribeToNewAggregationReceipts(api, callbackB, undefined, emitter).catch(
+      () => {},
+    );
+
+    resolveA(mockApiUnsubscribe);
+    resolveB(apiUnsubscribeB);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    unsubscribe(emitter);
+
+    expect(mockApiUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(apiUnsubscribeB).toHaveBeenCalledTimes(1);
+  });
+
+  // Bug 6
+  it('queries events via api.query.system.events.at, not api.at(...)', async () => {
+    const emitter = new EventEmitter();
+    const callback = jest.fn();
+    type FinalizedCb = (header: any) => Promise<void> | void;
+    const captured: { cb: FinalizedCb | null } = { cb: null };
+
+    (
+      api.rpc.chain.subscribeFinalizedHeads as unknown as jest.Mock
+    ).mockImplementation(async (...args: unknown[]) => {
+      captured.cb = args[0] as FinalizedCb;
+      return mockApiUnsubscribe;
+    });
+
+    // api.at must NOT be relied on — assert the path directly by leaving it
+    // unset on the mock and asserting events.at was called instead.
+    expect((api as any).at).toBeUndefined();
+
+    subscribeToNewAggregationReceipts(api, callback, undefined, emitter).catch(
+      () => {},
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    if (!captured.cb) throw new Error('Callback not captured');
+    await captured.cb({ hash: { toHex: () => '0xabc' } });
+
+    expect(mockEventsAt).toHaveBeenCalledWith('0xabc');
   });
 });

--- a/src/api/aggregation/index.ts
+++ b/src/api/aggregation/index.ts
@@ -6,6 +6,26 @@ import { ZkVerifyEvents } from '../../enums';
 import { NewAggregationEventSubscriptionOptions } from './types';
 import { Codec } from '@polkadot/types/types';
 
+type EmitterWithCleanups = EventEmitter & {
+  _cleanups?: Array<() => void>;
+};
+
+function registerCleanup(
+  emitter: EventEmitter,
+  cleanup: () => void,
+): () => void {
+  const e = emitter as EmitterWithCleanups;
+  if (!e._cleanups) e._cleanups = [];
+  e._cleanups.push(cleanup);
+
+  return () => {
+    const index = e._cleanups?.indexOf(cleanup) ?? -1;
+    if (index >= 0) {
+      e._cleanups?.splice(index, 1);
+    }
+  };
+}
+
 /**
  * Subscribes to `aggregation.NewAggregationReceipt` events and triggers the provided callback.
  *
@@ -35,8 +55,16 @@ export async function subscribeToNewAggregationReceipts(
     let unsubscribeFinalizedHeads: (() => void) | undefined;
     let isResolved = false;
     let isRejected = false;
+    // Set the moment cleanup() runs so a late-resolving subscribe Promise can
+    // invoke its unsubscribe fn instead of orphaning the polkadot subscription.
+    let wasCleanedUp = false;
+    let unregisterCleanup: (() => void) | undefined;
 
     const cleanup = () => {
+      wasCleanedUp = true;
+      unregisterCleanup?.();
+      unregisterCleanup = undefined;
+      emitter.removeListener(ZkVerifyEvents.Unsubscribe, cleanup);
       if (timeoutId) {
         clearTimeout(timeoutId);
         timeoutId = undefined;
@@ -67,8 +95,7 @@ export async function subscribeToNewAggregationReceipts(
       }
     };
 
-    (emitter as EventEmitter & { _cleanup?: () => void })._cleanup = cleanup;
-
+    unregisterCleanup = registerCleanup(emitter, cleanup);
     emitter.once(ZkVerifyEvents.Unsubscribe, cleanup);
 
     if (options) {
@@ -107,9 +134,12 @@ export async function subscribeToNewAggregationReceipts(
       const subscriptionResult = api.rpc.chain.subscribeFinalizedHeads(
         async (header) => {
           const blockHash = header.hash.toHex();
-          const apiAt = await api.at(blockHash);
-          const events =
-            (await apiAt.query.system.events()) as unknown as Vec<EventRecord>;
+          // Query the storage at a specific block hash without materializing a
+          // full ApiDecoration via api.at() — that creates per-block registry
+          // overhead and accumulates polkadot-api caches in long-lived subs.
+          const events = (await api.query.system.events.at(
+            blockHash,
+          )) as unknown as Vec<EventRecord>;
 
           events.forEach((record) => {
             const { event, phase } = record;
@@ -177,7 +207,6 @@ export async function subscribeToNewAggregationReceipts(
               ) {
                 emitter.emit(ZkVerifyEvents.NewAggregationReceipt, eventObject);
                 callback(eventObject);
-                cleanup();
                 safeResolve(emitter);
                 return;
               }
@@ -186,28 +215,34 @@ export async function subscribeToNewAggregationReceipts(
         },
       );
 
+      const handleUnsubscribeFn = (fn: unknown) => {
+        if (typeof fn !== 'function') return;
+        // If cleanup already ran (e.g. user called unsubscribe(emitter) before
+        // the subscribe handshake completed), invoke the unsubscribe fn now to
+        // avoid orphaning the polkadot subscription.
+        if (wasCleanedUp) {
+          try {
+            (fn as () => void)();
+          } catch (err) {
+            console.debug('Error during late finalized heads cleanup:', err);
+          }
+          return;
+        }
+        unsubscribeFinalizedHeads = fn as () => void;
+      };
+
       if (typeof subscriptionResult === 'function') {
-        unsubscribeFinalizedHeads = subscriptionResult;
+        handleUnsubscribeFn(subscriptionResult);
       } else if (
         subscriptionResult &&
         typeof subscriptionResult.then === 'function'
       ) {
-        subscriptionResult
-          .then((unsubscribeFn: () => void) => {
-            if (
-              !isResolved &&
-              !isRejected &&
-              typeof unsubscribeFn === 'function'
-            ) {
-              unsubscribeFinalizedHeads = unsubscribeFn;
-            }
-          })
-          .catch((error: unknown) => {
-            if (!isResolved && !isRejected) {
-              emitter.emit(ZkVerifyEvents.ErrorEvent, error);
-              safeReject(error);
-            }
-          });
+        subscriptionResult.then(handleUnsubscribeFn).catch((error: unknown) => {
+          if (!isResolved && !isRejected) {
+            emitter.emit(ZkVerifyEvents.ErrorEvent, error);
+            safeReject(error);
+          }
+        });
       }
     } catch (error) {
       emitter.emit(ZkVerifyEvents.ErrorEvent, error);
@@ -227,12 +262,19 @@ export async function subscribeToNewAggregationReceipts(
  * @param {EventEmitter} emitter - The EventEmitter instance returned by the subscription.
  */
 export function unsubscribe(emitter: EventEmitter): void {
-  const emitterWithCleanup = emitter as EventEmitter & {
-    _cleanup?: () => void;
-  };
-  if (emitterWithCleanup._cleanup) {
-    emitterWithCleanup._cleanup();
-    delete emitterWithCleanup._cleanup;
+  const e = emitter as EmitterWithCleanups;
+  if (e._cleanups && e._cleanups.length > 0) {
+    // Run all registered cleanups; clear before running so re-entrant emits
+    // (e.g. from inside a cleanup) can't see stale entries.
+    const cleanups = e._cleanups;
+    e._cleanups = [];
+    for (const c of cleanups) {
+      try {
+        c();
+      } catch (err) {
+        console.debug('Error during emitter cleanup:', err);
+      }
+    }
   }
 
   emitter.emit(ZkVerifyEvents.Unsubscribe);

--- a/src/session/managers/events/index.test.ts
+++ b/src/session/managers/events/index.test.ts
@@ -1,0 +1,258 @@
+import {
+  jest,
+  describe,
+  beforeEach,
+  it,
+  expect,
+  afterEach,
+} from '@jest/globals';
+import { EventManager } from './index';
+import { ZkVerifyEvents } from '../../../enums';
+import { ApiPromise } from '@polkadot/api';
+import { ConnectionManager } from '../connection';
+import { EventEmitter } from 'events';
+
+type SystemEventsCb = (records: any[]) => void;
+
+interface SystemEventsHandshake {
+  resolve: (fn: () => void) => void;
+  reject: (err: unknown) => void;
+}
+
+interface MockApi {
+  api: ApiPromise;
+  systemEventsCalls: number;
+  callbacks: SystemEventsCb[];
+  handshakes: SystemEventsHandshake[];
+  emitBlockToCallback: (index: number, records: any[]) => void;
+  emitBlockToLatest: (records: any[]) => void;
+}
+
+function makeMockApi(): MockApi {
+  const callbacks: SystemEventsCb[] = [];
+  const handshakes: SystemEventsHandshake[] = [];
+
+  const systemEvents = jest.fn((cb: SystemEventsCb) => {
+    callbacks.push(cb);
+    return new Promise<() => void>((resolve, reject) => {
+      handshakes.push({ resolve, reject });
+    });
+  });
+
+  const api = {
+    rpc: { chain: { subscribeFinalizedHeads: jest.fn() } },
+    query: {
+      system: {
+        events: Object.assign(systemEvents, { at: jest.fn() }),
+      },
+    },
+  } as unknown as ApiPromise;
+
+  return {
+    api,
+    get systemEventsCalls() {
+      return systemEvents.mock.calls.length;
+    },
+    callbacks,
+    handshakes,
+    emitBlockToCallback: (index, records) => callbacks[index]?.(records),
+    emitBlockToLatest: (records) => callbacks[callbacks.length - 1]?.(records),
+  };
+}
+
+function makeRecord(section: string, method: string, dataValues: string[]) {
+  return {
+    event: {
+      section,
+      method,
+      data: {
+        toHuman: () => dataValues,
+        toString: () => dataValues.join(','),
+      },
+    },
+    phase: { toJSON: () => ({ ApplyExtrinsic: 0 }), toString: () => '' },
+  };
+}
+
+function makeAggregationReceiptRecord(
+  domainId: string,
+  aggregationId: string,
+  receipt: string,
+) {
+  const data = [domainId, aggregationId, receipt].map((value) => ({
+    toString: () => value,
+  })) as any[];
+  (data as any).toHuman = () => [domainId, aggregationId, receipt];
+
+  return {
+    event: {
+      section: 'aggregate',
+      method: 'NewAggregationReceipt',
+      data,
+    },
+    phase: { toJSON: () => ({ ApplyExtrinsic: 0 }), toString: () => '' },
+  };
+}
+
+describe('EventManager', () => {
+  let mock: MockApi;
+  let manager: EventManager;
+
+  beforeEach(() => {
+    mock = makeMockApi();
+    const connectionManager = {
+      api: mock.api,
+    } as unknown as ConnectionManager;
+    manager = new EventManager(connectionManager);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Bug 4
+  it('subscribes to api.query.system.events ONCE regardless of how many runtime events are subscribed', () => {
+    manager.subscribe();
+    expect(mock.systemEventsCalls).toBe(1);
+  });
+
+  // Bug 4 (dispatch correctness — fan-out from a single underlying subscription)
+  it('dispatches a single decoded EventRecord vector to multiple per-event listeners', () => {
+    const proofVerified = jest.fn();
+    const newProof = jest.fn();
+    manager.subscribe([
+      { event: ZkVerifyEvents.ProofVerified, callback: proofVerified },
+      { event: ZkVerifyEvents.NewProof, callback: newProof },
+    ]);
+
+    mock.emitBlockToLatest([
+      makeRecord('proof', 'ProofVerified', ['0xa']),
+      makeRecord('aggregate', 'NewProof', ['1', '2']),
+    ]);
+
+    expect(proofVerified).toHaveBeenCalledTimes(1);
+    expect(newProof).toHaveBeenCalledTimes(1);
+  });
+
+  // Bug 3
+  it('is idempotent: calling subscribe() twice does not re-register listeners', () => {
+    const cb1 = jest.fn();
+    const cb2 = jest.fn();
+    manager.subscribe([{ event: ZkVerifyEvents.ProofVerified, callback: cb1 }]);
+    manager.subscribe([{ event: ZkVerifyEvents.ProofVerified, callback: cb2 }]);
+
+    mock.emitBlockToLatest([makeRecord('proof', 'ProofVerified', ['0xa'])]);
+
+    // First subscription's callback fires; second is a no-op.
+    expect(cb1).toHaveBeenCalledTimes(1);
+    expect(cb2).not.toHaveBeenCalled();
+
+    // And the underlying polkadot subscription is still single.
+    expect(mock.systemEventsCalls).toBe(1);
+  });
+
+  // Bug 2
+  it('invokes a late-arriving system.events unsubscribe fn when unsubscribe() ran first', async () => {
+    manager.subscribe([{ event: ZkVerifyEvents.ProofVerified }]);
+
+    const unsubFn = jest.fn();
+    // Caller closes the manager before the subscribe-handshake Promise resolves.
+    manager.unsubscribe();
+    mock.handshakes[0].resolve(unsubFn);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(unsubFn).toHaveBeenCalledTimes(1);
+  });
+
+  // Bug 2 (happy path: unsubscribe fn invoked when manager closes after handshake)
+  it('invokes the system.events unsubscribe fn on unsubscribe() (post-handshake)', async () => {
+    manager.subscribe([{ event: ZkVerifyEvents.ProofVerified }]);
+
+    const unsubFn = jest.fn();
+    mock.handshakes[0].resolve(unsubFn);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    manager.unsubscribe();
+    expect(unsubFn).toHaveBeenCalledTimes(1);
+  });
+
+  // Subscribe-after-unsubscribe lifecycle: re-using a manager across cycles.
+  // Verifies (a) a fresh polkadot subscription is opened, (b) the new sub
+  // can dispatch events normally, and (c) the late-arriving unsubscribe fn
+  // from the PRIOR cycle is invoked immediately (not orphaned, and not held
+  // for the next cycle's unsubscribe).
+  it('supports subscribe → unsubscribe → subscribe and invalidates the old cycle', async () => {
+    const cb1 = jest.fn();
+    const cb2 = jest.fn();
+    manager.subscribe([{ event: ZkVerifyEvents.ProofVerified, callback: cb1 }]);
+
+    // First cycle: close before the handshake resolves.
+    manager.unsubscribe();
+
+    // Second cycle: open a fresh subscription.
+    manager.subscribe([{ event: ZkVerifyEvents.NewProof, callback: cb2 }]);
+    expect(mock.systemEventsCalls).toBe(2);
+
+    // First cycle's handshake completes late.
+    const oldUnsub = jest.fn();
+    mock.handshakes[0].resolve(oldUnsub);
+    await new Promise((resolve) => setImmediate(resolve));
+    // Must be invoked immediately — generation mismatch detected.
+    expect(oldUnsub).toHaveBeenCalledTimes(1);
+
+    // Second cycle's handshake completes.
+    const newUnsub = jest.fn();
+    mock.handshakes[1].resolve(newUnsub);
+    await new Promise((resolve) => setImmediate(resolve));
+    // Must NOT be invoked yet — manager is still open in the new cycle.
+    expect(newUnsub).not.toHaveBeenCalled();
+
+    // The new cycle's subscription still receives and dispatches events.
+    mock.emitBlockToCallback(1, [makeRecord('aggregate', 'NewProof', ['x'])]);
+    expect(cb2).toHaveBeenCalledTimes(1);
+    expect(cb1).not.toHaveBeenCalled();
+
+    // First cycle's polkadot callback ignores any stale records (defensive).
+    mock.emitBlockToCallback(0, [
+      makeRecord('proof', 'ProofVerified', ['stale']),
+    ]);
+    expect(cb1).not.toHaveBeenCalled();
+
+    // Closing the new cycle invokes its unsubscribe fn.
+    manager.unsubscribe();
+    expect(newUnsub).toHaveBeenCalledTimes(1);
+  });
+
+  it('waitForAggregationReceipt resolves array payloads and releases its listener', async () => {
+    const finalizedHeadsUnsub = jest.fn();
+    let finalizedHeadCallback!: (header: any) => Promise<void> | void;
+
+    (
+      mock.api.rpc.chain.subscribeFinalizedHeads as unknown as jest.Mock
+    ).mockImplementation(async (...args: unknown[]) => {
+      const callback = args[0] as (header: any) => Promise<void>;
+      finalizedHeadCallback = callback;
+      return finalizedHeadsUnsub;
+    });
+    ((mock.api.query.system.events as any).at as jest.Mock).mockImplementation(
+      async () => [makeAggregationReceiptRecord('7', '9', '0xreceipt')],
+    );
+
+    const receiptPromise = manager.waitForAggregationReceipt(7, 9, 1000);
+    await new Promise((resolve) => setImmediate(resolve));
+    await finalizedHeadCallback({ hash: { toHex: () => '0xblock' } });
+
+    await expect(receiptPromise).resolves.toEqual({
+      blockHash: '0xblock',
+      domainId: 7,
+      aggregationId: 9,
+      receipt: '0xreceipt',
+    });
+    expect(finalizedHeadsUnsub).toHaveBeenCalledTimes(1);
+    expect(
+      ((manager as any).emitter as EventEmitter).listenerCount(
+        ZkVerifyEvents.Unsubscribe,
+      ),
+    ).toBe(0);
+  });
+});

--- a/src/session/managers/events/index.ts
+++ b/src/session/managers/events/index.ts
@@ -14,10 +14,37 @@ import {
   SubscriptionEntry,
 } from '../../../types';
 
+type RuntimeEventHandler = (records: EventRecord[]) => void;
+
 export class EventManager {
   private readonly connectionManager: ConnectionManager;
   private readonly emitter: EventEmitter;
   private readonly unsubscribeFunctions: Array<() => void> = [];
+
+  // Per-event-type handlers. We only ever register a SINGLE
+  // api.query.system.events callback per EventManager and dispatch from there
+  // — registering one polkadot subscription per event type would decode the
+  // whole EventRecord vector once per subscriber on every block.
+  private readonly runtimeEventHandlers = new Map<
+    ZkVerifyEvents,
+    RuntimeEventHandler
+  >();
+  private systemEventsSubscribed = false;
+  // Tracks which ZkVerifyEvents the caller has already subscribed to so a
+  // second subscribe() call doesn't double-register listeners (and double the
+  // codec/event traffic on every block).
+  private readonly subscribedEvents = new Set<ZkVerifyEvents>();
+  // True after unsubscribe() has been called; pending async unsubscribe fns
+  // must be invoked immediately rather than pushed into an array nothing
+  // iterates again. Reset to false at the top of subscribe() so the manager
+  // can be re-used after an unsubscribe()/subscribe() cycle.
+  private isClosed = false;
+  // Bumped every time a NEW underlying api.query.system.events subscription
+  // is established. The handshake .then handler captures the generation it
+  // was set up under and bails (invoking the unsubscribe fn immediately) if
+  // the manager has moved on — closing this avoids cross-cycle leaks where
+  // an old handshake completes after a re-subscribe and orphans its sub.
+  private systemEventsGeneration = 0;
 
   constructor(connectionManager: ConnectionManager) {
     this.connectionManager = connectionManager;
@@ -29,10 +56,16 @@ export class EventManager {
    * For `NewAggregationReceipt`, `options` can include `domainId` and `aggregationId`.
    * For runtime events (e.g., ProofVerified), options are ignored.
    *
+   * Idempotent: subscribing to an event already subscribed to is a no-op for
+   * that event (other entries in the same call are still processed).
+   *
    * @param subscriptions - List of events to subscribe to with optional callback and filtering options.
    * @returns EventEmitter to allow listening to additional internal events (e.g., `Unsubscribe`).
    */
   subscribe(subscriptions?: SubscriptionEntry[]): EventEmitter {
+    // Allow re-subscribing after a previous unsubscribe() — the generation
+    // counter on system.events guards stale handshakes from the prior cycle.
+    this.isClosed = false;
     const { api } = this.connectionManager;
 
     const eventsToSubscribe: SubscriptionEntry[] = subscriptions?.length
@@ -49,8 +82,13 @@ export class EventManager {
         );
 
     eventsToSubscribe.forEach(({ event, callback, options }) => {
+      if (this.subscribedEvents.has(event)) {
+        return;
+      }
+
       switch (event) {
         case ZkVerifyEvents.NewAggregationReceipt:
+          this.subscribedEvents.add(event);
           subscribeToNewAggregationReceipts(
             api,
             (data) => {
@@ -68,7 +106,9 @@ export class EventManager {
         case ZkVerifyEvents.NewDomain:
         case ZkVerifyEvents.DomainStateChanged:
         case ZkVerifyEvents.AggregationComplete:
-          this._subscribeToRuntimeEvent(api, event, callback);
+        case ZkVerifyEvents.CannotAggregate:
+          this.subscribedEvents.add(event);
+          this._registerRuntimeEvent(api, event, callback);
           break;
 
         default:
@@ -80,64 +120,96 @@ export class EventManager {
   }
 
   /**
-   * Subscribes to on-chain runtime events using api.query.system.events
+   * Registers a per-event handler against the shared system.events
+   * subscription, lazily creating that subscription on first use.
    */
-  private _subscribeToRuntimeEvent(
+  private _registerRuntimeEvent(
     api: ApiPromise,
     eventType: ZkVerifyEvents,
     callback?: (data: unknown) => void,
-  ) {
-    const unsubscribeFn = api.query.system.events((records: EventRecord[]) => {
+  ): void {
+    const matchMap: Partial<Record<ZkVerifyEvents, string | RegExp>> = {
+      [ZkVerifyEvents.ProofVerified]: /::ProofVerified/,
+      [ZkVerifyEvents.CannotAggregate]: 'aggregate::CannotAggregate',
+      [ZkVerifyEvents.NewProof]: 'aggregate::NewProof',
+      [ZkVerifyEvents.VkRegistered]: /::VkRegistered/,
+      [ZkVerifyEvents.AggregationComplete]: 'aggregate::AggregationComplete',
+      [ZkVerifyEvents.NewDomain]: 'aggregate::NewDomain',
+      [ZkVerifyEvents.DomainStateChanged]: 'aggregate::DomainStateChanged',
+    };
+
+    const handler: RuntimeEventHandler = (records) => {
       for (const { event, phase } of records) {
         const key = `${event.section}::${event.method}`;
+        const expected = matchMap[eventType];
+        if (!expected) continue;
 
-        const matchMap: Partial<Record<ZkVerifyEvents, string | RegExp>> = {
-          [ZkVerifyEvents.ProofVerified]: /::ProofVerified/,
-          [ZkVerifyEvents.CannotAggregate]: 'aggregate::CannotAggregate',
-          [ZkVerifyEvents.NewProof]: 'aggregate::NewProof',
-          [ZkVerifyEvents.VkRegistered]: /::VkRegistered/,
-          [ZkVerifyEvents.AggregationComplete]:
-            'aggregate::AggregationComplete',
-          [ZkVerifyEvents.NewDomain]: 'aggregate::NewDomain',
-          [ZkVerifyEvents.DomainStateChanged]: 'aggregate::DomainStateChanged',
+        const matches =
+          (typeof expected === 'string' && key === expected) ||
+          (expected instanceof RegExp && expected.test(key));
+        if (!matches) continue;
+
+        const parsedPhase = phase.toJSON ? phase.toJSON() : phase.toString();
+        const eventPayload = {
+          event: eventType,
+          data: event.data.toHuman?.() ?? event.data.toString(),
+          phase: parsedPhase,
         };
 
-        const expected = matchMap[eventType];
-        if (
-          expected &&
-          ((typeof expected === 'string' && key === expected) ||
-            (expected instanceof RegExp && expected.test(key)))
-        ) {
-          const parsedPhase = phase.toJSON ? phase.toJSON() : phase.toString();
+        this.emitter.emit(eventType, eventPayload);
+        if (callback) callback(eventPayload);
+      }
+    };
 
-          const eventPayload = {
-            event: eventType,
-            data: event.data.toHuman?.() ?? event.data.toString(),
-            phase: parsedPhase,
-          };
+    this.runtimeEventHandlers.set(eventType, handler);
+    this._ensureSystemEventsSubscription(api);
+  }
 
-          this.emitter.emit(eventType, eventPayload);
+  private _ensureSystemEventsSubscription(api: ApiPromise): void {
+    if (this.systemEventsSubscribed) return;
+    this.systemEventsSubscribed = true;
+    const myGeneration = ++this.systemEventsGeneration;
 
-          if (callback) {
-            callback(eventPayload);
+    const subscriptionResult = api.query.system.events(
+      (records: EventRecord[]) => {
+        // If a newer cycle has replaced this subscription (or the manager
+        // closed) but the polkadot unsubscribe fn hasn't fired yet, drop
+        // these records — the handlers Map may belong to a different cycle.
+        if (myGeneration !== this.systemEventsGeneration) return;
+        for (const handler of this.runtimeEventHandlers.values()) {
+          try {
+            handler(records);
+          } catch (err) {
+            this.emitter.emit(ZkVerifyEvents.ErrorEvent, err);
           }
         }
-      }
-    });
+      },
+    );
 
-    if (unsubscribeFn) {
-      if (typeof unsubscribeFn === 'function') {
-        this.unsubscribeFunctions.push(unsubscribeFn);
-      } else if (unsubscribeFn && typeof unsubscribeFn.then === 'function') {
-        unsubscribeFn
-          .then((fn) => {
-            if (typeof fn === 'function') {
-              this.unsubscribeFunctions.push(fn);
-            }
-          })
-          .catch((error: unknown) => {
-            this.emitter.emit(ZkVerifyEvents.ErrorEvent, error);
-          });
+    const handleUnsubscribeFn = (fn: unknown) => {
+      if (typeof fn !== 'function') return;
+      // Invoke the unsubscribe fn immediately if either (a) the manager has
+      // been closed since the handshake started, or (b) a newer system.events
+      // subscription has replaced this one. Either case would otherwise leave
+      // the polkadot subscription orphaned.
+      if (this.isClosed || myGeneration !== this.systemEventsGeneration) {
+        try {
+          (fn as () => void)();
+        } catch (error) {
+          console.debug('Error during late runtime-event cleanup:', error);
+        }
+        return;
+      }
+      this.unsubscribeFunctions.push(fn as () => void);
+    };
+
+    if (subscriptionResult) {
+      if (typeof subscriptionResult === 'function') {
+        handleUnsubscribeFn(subscriptionResult);
+      } else if (typeof subscriptionResult.then === 'function') {
+        subscriptionResult.then(handleUnsubscribeFn).catch((error: unknown) => {
+          this.emitter.emit(ZkVerifyEvents.ErrorEvent, error);
+        });
       }
     }
   }
@@ -164,19 +236,27 @@ export class EventManager {
         api,
         (eventObject: unknown) => {
           const event = eventObject as NewAggregationReceiptEvent;
+          const data = event?.data;
+          const receiptData = Array.isArray(data)
+            ? {
+                domainId: data[0],
+                aggregationId: data[1],
+                receipt: data[2],
+              }
+            : data;
 
           if (
             event &&
-            event.data &&
-            event.data.domainId &&
-            event.data.aggregationId &&
-            event.data.receipt
+            receiptData &&
+            receiptData.domainId !== undefined &&
+            receiptData.aggregationId !== undefined &&
+            receiptData.receipt !== undefined
           ) {
             const result: NewAggregationReceipt = {
               blockHash: event.blockHash ?? null,
-              domainId: Number(event.data.domainId),
-              aggregationId: Number(event.data.aggregationId),
-              receipt: String(event.data.receipt),
+              domainId: Number(receiptData.domainId),
+              aggregationId: Number(receiptData.aggregationId),
+              receipt: String(receiptData.receipt),
             };
 
             resolve(result);
@@ -194,6 +274,12 @@ export class EventManager {
    * Unsubscribes from all active subscriptions.
    */
   unsubscribe(): void {
+    this.isClosed = true;
+    // Bumping the generation invalidates any in-flight system.events handshake
+    // from this cycle — when its .then resolves, handleUnsubscribeFn will see
+    // the mismatch and invoke the unsubscribe fn immediately.
+    this.systemEventsGeneration += 1;
+
     this.unsubscribeFunctions.forEach((unsubscribeFn) => {
       try {
         unsubscribeFn();
@@ -202,6 +288,9 @@ export class EventManager {
       }
     });
     this.unsubscribeFunctions.length = 0;
+    this.runtimeEventHandlers.clear();
+    this.subscribedEvents.clear();
+    this.systemEventsSubscribed = false;
 
     unsubscribe(this.emitter);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,11 +113,13 @@ export type Delivery = { None: null };
 export interface NewAggregationReceiptEvent {
   event: ZkVerifyEvents;
   blockHash: string;
-  data: {
-    domainId?: string;
-    aggregationId?: string;
-    receipt?: string;
-  };
+  data:
+    | {
+        domainId?: string | number;
+        aggregationId?: string | number;
+        receipt?: string;
+      }
+    | Array<string | number>;
   phase: string;
 }
 

--- a/src/utils/transactions/index.test.ts
+++ b/src/utils/transactions/index.test.ts
@@ -1,0 +1,135 @@
+import { jest, describe, it, expect } from '@jest/globals';
+import { EventEmitter } from 'events';
+import { ApiPromise, SubmittableResult } from '@polkadot/api';
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { KeyringPair } from '@polkadot/keyring/types';
+import { ProofType } from '../../config';
+import { TransactionStatus, TransactionType } from '../../enums';
+import { VerifyOptions } from '../../session/types';
+import { handleTransaction } from './index';
+
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('handleTransaction', () => {
+  const finalizedResult = {
+    status: {
+      isBroadcast: false,
+      isInBlock: false,
+      isFinalized: true,
+      isInvalid: false,
+    },
+    dispatchError: undefined,
+    events: [],
+  } as unknown as SubmittableResult;
+
+  it('invokes a late-arriving signAndSend unsubscribe after finalization', async () => {
+    let capturedCallback!: (result: SubmittableResult) => Promise<void>;
+    let resolveUnsubscribe!: (fn: () => void) => void;
+    const unsubscribe = jest.fn();
+
+    const submitExtrinsic = {
+      signAndSend: jest.fn(
+        (
+          _account: KeyringPair,
+          _options: unknown,
+          callback: (result: SubmittableResult) => Promise<void>,
+        ) => {
+          capturedCallback = callback;
+          return new Promise<() => void>((resolve) => {
+            resolveUnsubscribe = resolve;
+          });
+        },
+      ),
+    } as unknown as SubmittableExtrinsic<'promise'>;
+
+    const transactionPromise = handleTransaction(
+      {} as ApiPromise,
+      submitExtrinsic,
+      {} as KeyringPair,
+      undefined,
+      new EventEmitter(),
+      {
+        proofOptions: { proofType: ProofType.groth16 },
+      } as VerifyOptions,
+      TransactionType.Verify,
+    );
+
+    await capturedCallback(finalizedResult);
+
+    await expect(transactionPromise).resolves.toEqual(
+      expect.objectContaining({ status: TransactionStatus.Finalized }),
+    );
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    resolveUnsubscribe(unsubscribe);
+    await flushMicrotasks();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up many concurrent transactions with late signAndSend unsubscribe fns', async () => {
+    const transactionCount = 250;
+    const capturedCallbacks: Array<
+      (result: SubmittableResult) => Promise<void>
+    > = [];
+    const resolveUnsubscribes: Array<(fn: () => void) => void> = [];
+    const unsubscribeFns = Array.from({ length: transactionCount }, () =>
+      jest.fn(),
+    );
+
+    const makeSubmitExtrinsic = (index: number) =>
+      ({
+        signAndSend: jest.fn(
+          (
+            _account: KeyringPair,
+            _options: unknown,
+            callback: (result: SubmittableResult) => Promise<void>,
+          ) => {
+            capturedCallbacks[index] = callback;
+            return new Promise<() => void>((resolve) => {
+              resolveUnsubscribes[index] = resolve;
+            });
+          },
+        ),
+      }) as unknown as SubmittableExtrinsic<'promise'>;
+
+    const transactionPromises = Array.from(
+      { length: transactionCount },
+      (_, index) =>
+        handleTransaction(
+          {} as ApiPromise,
+          makeSubmitExtrinsic(index),
+          {} as KeyringPair,
+          undefined,
+          new EventEmitter(),
+          {
+            proofOptions: { proofType: ProofType.groth16 },
+          } as VerifyOptions,
+          TransactionType.Verify,
+        ),
+    );
+
+    await Promise.all(
+      capturedCallbacks.map((callback) => callback(finalizedResult)),
+    );
+    await expect(Promise.all(transactionPromises)).resolves.toHaveLength(
+      transactionCount,
+    );
+    expect(
+      unsubscribeFns.every(
+        (unsubscribe) => unsubscribe.mock.calls.length === 0,
+      ),
+    ).toBe(true);
+
+    resolveUnsubscribes.forEach((resolve, index) =>
+      resolve(unsubscribeFns[index]),
+    );
+    await flushMicrotasks();
+
+    expect(
+      unsubscribeFns.every(
+        (unsubscribe) => unsubscribe.mock.calls.length === 1,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/utils/transactions/index.ts
+++ b/src/utils/transactions/index.ts
@@ -39,8 +39,9 @@ export const handleTransaction = async <T extends TransactionType>(
 
   return new Promise((resolve, reject) => {
     let unsubscribeFn: (() => void) | undefined;
+    let isCompleted = false;
 
-    const cancelTransaction = (error: unknown) => {
+    const cleanupTransaction = () => {
       if (unsubscribeFn) {
         try {
           unsubscribeFn();
@@ -49,6 +50,26 @@ export const handleTransaction = async <T extends TransactionType>(
         }
         unsubscribeFn = undefined;
       }
+    };
+
+    const handleUnsubscribeFn = (fn: unknown) => {
+      if (typeof fn !== 'function') return;
+
+      if (isCompleted) {
+        try {
+          fn();
+        } catch (err) {
+          console.debug('Error during late transaction cleanup:', err);
+        }
+        return;
+      }
+
+      unsubscribeFn = fn as () => void;
+    };
+
+    const cancelTransaction = (error: unknown) => {
+      isCompleted = true;
+      cleanupTransaction();
 
       if (transactionInfo.status !== TransactionStatus.Error) {
         transactionInfo.status = TransactionStatus.Error;
@@ -77,14 +98,8 @@ export const handleTransaction = async <T extends TransactionType>(
           transactionType,
         );
 
-        if (unsubscribeFn) {
-          try {
-            unsubscribeFn();
-          } catch (err) {
-            console.debug('Error during transaction cleanup:', err);
-          }
-          unsubscribeFn = undefined;
-        }
+        isCompleted = true;
+        cleanupTransaction();
 
         resolve(transactionInfo);
       } catch (error) {
@@ -135,20 +150,16 @@ export const handleTransaction = async <T extends TransactionType>(
       );
 
       if (typeof unsubscribeResult === 'function') {
-        unsubscribeFn = unsubscribeResult;
+        handleUnsubscribeFn(unsubscribeResult);
       } else if (
         unsubscribeResult &&
         typeof unsubscribeResult.then === 'function'
       ) {
-        unsubscribeResult
-          .then((fn) => {
-            if (typeof fn === 'function') {
-              unsubscribeFn = fn;
-            }
-          })
-          .catch((error) => {
+        unsubscribeResult.then(handleUnsubscribeFn).catch((error) => {
+          if (!isCompleted) {
             cancelTransaction(error);
-          });
+          }
+        });
       }
     } catch (error) {
       cancelTransaction(error);

--- a/tests/common/scripts/live-execute-heap.cjs
+++ b/tests/common/scripts/live-execute-heap.cjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+/**
+ * Sends live `.execute()` transactions and writes a heap snapshot for cleanup
+ * diagnostics.
+ *
+ * Requirements:
+ * - A funded SEED_PHRASE* value in the repo .env file, or set ZKV_HEAP_DOTENV.
+ * - Run with --expose-gc so the script can force GC before snapshotting.
+ *
+ * Example:
+ *   node --expose-gc tests/common/scripts/live-execute-heap.cjs \
+ *     --label=fixed-live-race --count=1 --force-late-unsubscribe=true
+ *
+ * Heap snapshots are written to tmp/ by default, which is gitignored.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const v8 = require('v8');
+
+process.env.TS_NODE_COMPILER_OPTIONS ??= JSON.stringify({
+  module: 'commonjs',
+});
+require('ts-node/register/transpile-only');
+
+require('dotenv').config({
+  path:
+    process.env.ZKV_HEAP_DOTENV ||
+    path.resolve(__dirname, '..', '..', '..', '.env'),
+});
+
+const {
+  zkVerifySession,
+  ProofType,
+  Library,
+  CurveType,
+  ZkVerifyEvents,
+} = require('../../../src');
+
+const proofData = require('../data/groth16_snarkjs_bn254.json');
+
+const args = new Map(
+  process.argv.slice(2).map((arg) => {
+    const [key, value = 'true'] = arg.replace(/^--/, '').split('=');
+    return [key, value];
+  }),
+);
+
+const label = args.get('label') || 'execute-heap';
+const txCount = Number(args.get('count') || 1);
+const unsubscribeDelayMs = Number(args.get('unsubscribe-delay-ms') || 500);
+const forceLateUnsubscribe = args.get('force-late-unsubscribe') !== 'false';
+const showTxHashes = args.get('show-tx-hashes') === 'true';
+const outDir = path.resolve(
+  args.get('out-dir') ||
+    path.join(process.cwd(), 'tmp', 'live-execute-heap'),
+);
+
+let unsubscribeFunctionsDelivered = 0;
+let unsubscribeFunctionsInvoked = 0;
+
+function firstSeedPhrase() {
+  const entry = Object.entries(process.env).find(
+    ([key, value]) =>
+      key.startsWith('SEED_PHRASE') &&
+      typeof value === 'string' &&
+      value.trim().split(/\s+/).length === 12,
+  );
+
+  if (!entry) {
+    throw new Error('No valid SEED_PHRASE* value found for live heap run.');
+  }
+
+  return entry[1];
+}
+
+function forceGc(rounds = 5) {
+  if (typeof global.gc !== 'function') {
+    throw new Error('Run node with --expose-gc for heap diagnostics.');
+  }
+
+  for (let i = 0; i < rounds; i += 1) {
+    global.gc();
+  }
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function instrumentSignAndSendUnsubscribe(extrinsic) {
+  const original = extrinsic.signAndSend.bind(extrinsic);
+
+  extrinsic.signAndSend = (...signAndSendArgs) => {
+    let finalizedSeen = false;
+    let finalizedResolve;
+    const finalizedPromise = new Promise((resolve) => {
+      finalizedResolve = resolve;
+    });
+    const callbackIndex = signAndSendArgs.length - 1;
+    const originalCallback = signAndSendArgs[callbackIndex];
+
+    if (typeof originalCallback === 'function') {
+      signAndSendArgs[callbackIndex] = async (result) => {
+        try {
+          await originalCallback(result);
+        } finally {
+          if (result?.status?.isFinalized && !finalizedSeen) {
+            finalizedSeen = true;
+            finalizedResolve();
+          }
+        }
+      };
+    }
+
+    const result = original(...signAndSendArgs);
+
+    const wrapUnsubscribe = async (unsubscribe) => {
+      if (forceLateUnsubscribe) {
+        await finalizedPromise;
+      }
+      await delay(unsubscribeDelayMs);
+
+      unsubscribeFunctionsDelivered += 1;
+      return () => {
+        unsubscribeFunctionsInvoked += 1;
+        return unsubscribe();
+      };
+    };
+
+    if (result && typeof result.then === 'function') {
+      return result.then(wrapUnsubscribe);
+    }
+
+    if (typeof result === 'function') {
+      return wrapUnsubscribe(result);
+    }
+
+    return result;
+  };
+
+  return extrinsic;
+}
+
+async function sendOne(session, index) {
+  const proofOptions = {
+    proofType: ProofType.groth16,
+    config: { library: Library.snarkjs, curve: CurveType.bn254 },
+  };
+
+  const formatted = await session.format(
+    proofOptions,
+    proofData.proof,
+    proofData.publicSignals,
+    proofData.vk,
+  );
+
+  const extrinsic = instrumentSignAndSendUnsubscribe(
+    await session.createSubmitProofExtrinsic(ProofType.groth16, formatted),
+  );
+
+  const { events, transactionResult } = await session
+    .verify()
+    .groth16({ library: Library.snarkjs, curve: CurveType.bn254 })
+    .execute({ extrinsic });
+
+  events.on(ZkVerifyEvents.Broadcast, ({ txHash }) => {
+    console.log(
+      `[${label}] tx ${index} broadcast${showTxHashes ? ` ${txHash}` : ''}`,
+    );
+  });
+  events.on(ZkVerifyEvents.Finalized, ({ txHash, blockHash }) => {
+    console.log(
+      `[${label}] tx ${index} finalized${
+        showTxHashes ? ` ${txHash} ${blockHash}` : ''
+      }`,
+    );
+  });
+  events.on(ZkVerifyEvents.ErrorEvent, (error) => {
+    console.error(`[${label}] tx ${index} error`, error);
+  });
+
+  const result = await transactionResult;
+  events.removeAllListeners();
+  return result.txHash;
+}
+
+function analyzeSnapshot(snapshotPath) {
+  const data = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+  const meta = data.snapshot.meta;
+  const nodeFields = meta.node_fields;
+  const edgeFields = meta.edge_fields;
+  const nodeTypes = meta.node_types[0];
+  const edgeTypes = meta.edge_types[0];
+  const nodeIndex = Object.fromEntries(nodeFields.map((field, i) => [field, i]));
+  const edgeIndex = Object.fromEntries(edgeFields.map((field, i) => [field, i]));
+  const nodeStride = nodeFields.length;
+  const edgeStride = edgeFields.length;
+  const { nodes, edges, strings } = data;
+  const nodeCount = nodes.length / nodeStride;
+
+  const edgeStarts = new Array(nodeCount + 1);
+  let edgeOffset = 0;
+  for (let i = 0; i < nodeCount; i += 1) {
+    edgeStarts[i] = edgeOffset;
+    edgeOffset += nodes[i * nodeStride + nodeIndex.edge_count] * edgeStride;
+  }
+  edgeStarts[nodeCount] = edgeOffset;
+
+  const analysis = {
+    handleTransactionContexts: 0,
+    cancelTransactionClosures: 0,
+    finalizeTransactionClosures: 0,
+  };
+
+  for (let nodeId = 0; nodeId < nodeCount; nodeId += 1) {
+    const nodeOffset = nodeId * nodeStride;
+    const nodeType = nodeTypes[nodes[nodeOffset + nodeIndex.type]];
+    const nodeName = strings[nodes[nodeOffset + nodeIndex.name]];
+
+    if (nodeType === 'closure' && nodeName === 'cancelTransaction') {
+      analysis.cancelTransactionClosures += 1;
+    }
+    if (nodeType === 'closure' && nodeName === 'finalizeTransaction') {
+      analysis.finalizeTransactionClosures += 1;
+    }
+    if (nodeType !== 'object' || nodeName !== 'system / Context') {
+      continue;
+    }
+
+    const contextEdgeNames = new Set();
+    for (
+      let currentEdge = edgeStarts[nodeId];
+      currentEdge < edgeStarts[nodeId + 1];
+      currentEdge += edgeStride
+    ) {
+      const edgeType = edgeTypes[edges[currentEdge + edgeIndex.type]];
+      if (edgeType !== 'context') continue;
+
+      contextEdgeNames.add(strings[edges[currentEdge + edgeIndex.name_or_index]]);
+    }
+
+    if (
+      contextEdgeNames.has('unsubscribeFn') &&
+      contextEdgeNames.has('cancelTransaction') &&
+      contextEdgeNames.has('finalizeTransaction')
+    ) {
+      analysis.handleTransactionContexts += 1;
+    }
+  }
+
+  return analysis;
+}
+
+async function main() {
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const seedPhrase = firstSeedPhrase();
+  const session = await zkVerifySession.start().Volta().withAccount(seedPhrase);
+  const txHashes = [];
+
+  try {
+    for (let i = 1; i <= txCount; i += 1) {
+      txHashes.push(await sendOne(session, i));
+    }
+
+    await delay(unsubscribeDelayMs + 500);
+    forceGc();
+
+    const snapshotPath = v8.writeHeapSnapshot(
+      path.join(outDir, `${label}.heapsnapshot`),
+    );
+
+    console.log(
+      JSON.stringify(
+        {
+          label,
+          txCount,
+          forceLateUnsubscribe,
+          snapshotPath,
+          txHashes: showTxHashes ? txHashes : undefined,
+          unsubscribeFunctionsDelivered,
+          unsubscribeFunctionsInvoked,
+          analysis: analyzeSnapshot(snapshotPath),
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await session.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Fix cleanup races where async Polkadot unsubscribe functions can arrive after proof execution, event waiting, or event subscription teardown has already completed. Late unsubscribe functions are now invoked immediately instead of being retained in resolved transaction or subscription closures.

Harden aggregation and runtime event subscription lifecycle handling by removing resolved cleanup handlers, deduplicating runtime event subscriptions, supporting subscribe/unsubscribe/resubscribe cycles, and parsing array-shaped aggregation receipt payloads in waitForAggregationReceipt.

Add focused regressions for single and concurrent .execute() cleanup, aggregation receipt listener cleanup, late subscription handshakes, event subscription idempotency, and stale subscription generation handling. Add a sanitized live heap diagnostic script under tests/common/scripts for future public-safe leak investigation without committing heap artifacts.